### PR TITLE
6 modbustcp on timeout the timercallback never exits

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -53,7 +53,7 @@ test_framework = unity
 lib_deps = 
     ./
 build_flags = 
-    -D EZMODBUS_DEBUG
+    ; -D EZMODBUS_DEBUG
     ; -fstack-usage
 test_filter = test_tcp_client_loopback
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -53,7 +53,7 @@ test_framework = unity
 lib_deps = 
     ./
 build_flags = 
-    ; -D EZMODBUS_DEBUG
+    -D EZMODBUS_DEBUG
     ; -fstack-usage
 test_filter = test_tcp_client_loopback
 

--- a/src/interfaces/ModbusTCP.cpp
+++ b/src/interfaces/ModbusTCP.cpp
@@ -545,6 +545,10 @@ uint16_t TCP::getNextOutgoingTransactionId() {
  * @note IMPORTANT: must ONLY be called from rxTxTask context!
  */
 bool TCP::beginTransaction(int socketNum, uint16_t transactionId) {
+    if (_currentTransaction.active) {
+        Modbus::Debug::LOG_MSG("Transaction already in progress");
+        return false;
+    }
     _currentTransaction.set(socketNum, transactionId);
     Modbus::Debug::LOG_MSGF("Transaction started on socket: %d with TID: %d", socketNum, transactionId);
     return true;

--- a/src/interfaces/ModbusTCP.h
+++ b/src/interfaces/ModbusTCP.h
@@ -110,8 +110,7 @@ private:
     Mutex _txMutex; // Protects access to _txBuffer & _txCtx
 
     // Transaction management
-    TransactionCtx _currentTransaction;
-    Mutex _transactionMutex;
+    TransactionCtx _currentTransaction; // IMPORTANT: must ONLY be accessed from rxTxTask context!
 
     // Data processing
     // _rxEventQueue: receives RX events from HAL (only the handle, belongs to HAL layer)
@@ -121,7 +120,11 @@ private:
     StaticQueue_t _txRequestQueueBuffer;
     alignas(4) uint8_t _txRequestQueueStorage[1 * sizeof(void*)];
     QueueHandle_t _txRequestQueue = nullptr;
-    // _eventQueueSet: Combines RX event queue + HAL event queue
+    // _txnControlQueue: only rxTxTask terminates transaction through this queue
+    StaticQueue_t _txnControlQueueBuffer;
+    alignas(4) uint8_t _txnControlQueueStorage[1 * sizeof(void*)];
+    QueueHandle_t _txnControlQueue = nullptr;
+    // _eventQueueSet: Combines TX event queue + HAL event queue + Txn control queue
     QueueSetHandle_t _eventQueueSet = nullptr;
 
     // ===================================================================================

--- a/src/interfaces/ModbusTCP.h
+++ b/src/interfaces/ModbusTCP.h
@@ -55,7 +55,7 @@ public:
         uint16_t tid = 0;
 
         void set(int socketNum, uint16_t tid) { active=true; startMs=TIME_MS(); this->socketNum=socketNum; this->tid=tid; }
-        void clear() { active=false; startMs=0; socketNum=-1; tid=0; }
+        void clear() { socketNum=-1; startMs=0; tid=0; active=false; }
     };
 
     /* @brief Stores the current transmission data context
@@ -110,7 +110,7 @@ private:
     Mutex _txMutex; // Protects access to _txBuffer & _txCtx
 
     // Transaction management
-    TransactionCtx _currentTransaction; // IMPORTANT: must ONLY be accessed from rxTxTask context!
+    TransactionCtx _currentTransaction; // IMPORTANT: must ONLY be written from rxTxTask context!
 
     // Data processing
     // _rxEventQueue: receives RX events from HAL (only the handle, belongs to HAL layer)

--- a/src/interfaces/ModbusTCP.h
+++ b/src/interfaces/ModbusTCP.h
@@ -49,7 +49,7 @@ public:
 
     /* @brief Stores the current transaction context */
     struct TransactionCtx {
-        bool active = false;
+        volatile bool active = false;
         int startMs = 0;
         int socketNum = -1;
         uint16_t tid = 0;


### PR DESCRIPTION
There was a deadlock in the TCP transaction cleanup logic:
- When the client doesn't receive a response in time, the FreeRTOS timer calls `TCP::abortCurrentTransaction()` (public method) through `Client::timeoutCallback()` to try and abort the current TCP transaction
- This methods acquires the `_transactionMutex` and then calls `TCP::endCurrentTransaction()` (internal, private method) which itselfs expects to take a lot on the same mutex!

Consequence: no new Client request can be sent.

Instead of using a simple try-lock approach in the timer (which could be dramatic if it fails to take the mutex and ends up not clearing the transaction anyway), the `_currentTransaction` management logic was refactored:
- `_currentTransaction` state is now modified ONLY inside `rxTxTask` context, without any mutex (`_transactionMutex` removed)
- A new `_txnControlQueue` is created inside `Modbus::TCP` and added to the existing `QueueSet` checked inside `rxTxTask`
- The `endCurrentTransaction` method now just sends a signal in the `_txnControlQueue` to wake up the `rxTxTask`, and the existing transaction cleanup logic (in charge of applying the "TCP safety timeout") also handles cleanup request from the queue
- The existing checks on `_currentTransaction` from `TCP::sendFrame()` are untouched. They still check if a new Modbus message can be queued inside the `Modbus::TCP` TX buffer, and the `rxTxTask` is eventually responsible of deciding whether it should be sent on the line

It was also discovered that the current "TCP timeout test" does not properly handles the case where the server simply drops the response (which explains why the bug wasn't discovered in the first place). Timeout tests were refactored, we have now two test cases for TCP timeouts in `test_tcp_client_loopback`:
- `test_timeout_client_interface` simulates a stalled `rxTxTask` from client side and checks if the Client TCP interface is capable to recover gracefully
- `test_timeout_server` simulates a server that receives the request but does not send any response (the initial problematic case that wasn't properly covered)