### PR TITLE
12 improve concurrency in clientpendingrequest

### DIFF
--- a/docs/20-core-concepts/200-library-overview.md
+++ b/docs/20-core-concepts/200-library-overview.md
@@ -39,6 +39,7 @@ namespace Modbus {
     class Bridge;                   // Interface bridge/proxy
     
     struct Frame;                   // Modbus message abstraction
+    struct FrameMeta;               // Frame metadata (internal)
     struct Word;                    // Register abstraction (Server)
     
     class IWordStore;               // Abstract register storage

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,6 +20,9 @@ build_flags =
     -include test/test_codec/mock/ModbusDebug.h
     -I src
 test_filter = test_codec
+build_src_filter = 
+    +<*>
+    +<../test/test_codec/*> 
 
 [env:test_rtu_server_loopback]
 platform = espressif32
@@ -32,6 +35,9 @@ build_flags =
     ; -D EZMODBUS_DEBUG
     ; -fstack-usage
 test_filter = test_rtu_server_loopback
+build_src_filter = 
+    +<*>
+    +<../test/test_rtu_server_loopback/*> 
 
 [env:test_rtu_client_loopback]
 platform = espressif32
@@ -44,18 +50,24 @@ build_flags =
     ; -D EZMODBUS_DEBUG
     ; -fstack-usage
 test_filter = test_rtu_client_loopback
+build_src_filter = 
+    +<*>
+    +<../test/test_rtu_client_loopback/*> 
 
 [env:test_tcp_client_loopback]
 platform = espressif32
 board = seeed_xiao_esp32s3
 framework = arduino
 test_framework = unity
-lib_deps = 
+lib_deps =
     ./
-build_flags = 
+build_flags =
     ; -D EZMODBUS_DEBUG
     ; -fstack-usage
 test_filter = test_tcp_client_loopback
+build_src_filter = 
+    +<*>
+    +<../test/test_tcp_client_loopback/*> 
 
 [env:test_bridge_loopback]
 platform = espressif32
@@ -68,3 +80,6 @@ build_flags =
     ; -D EZMODBUS_DEBUG
     ; -fstack-usage
 test_filter = test_bridge_loopback
+build_src_filter = 
+    +<*>
+    +<../test/test_bridge_loopback/*> 

--- a/src/apps/ModbusClient.cpp
+++ b/src/apps/ModbusClient.cpp
@@ -65,7 +65,6 @@ bool Client::PendingRequest::killTimer(TickType_t maxWaitTicks) {
  * @param timer The timer handle containing TimerTag
  */
 void Client::PendingRequest::timeoutCallback(TimerHandle_t timer) {
-    if (!timer) return;
     auto* pendingReq = static_cast<PendingRequest*>(pvTimerGetTimerID(timer));
     if (!pendingReq) return;
 

--- a/src/apps/ModbusClient.cpp
+++ b/src/apps/ModbusClient.cpp
@@ -160,12 +160,11 @@ bool Client::PendingRequest::set(const Modbus::Frame& request, Modbus::Frame* re
  */
 bool Client::PendingRequest::set(const Modbus::Frame& request, Client::ResponseCallback cb,
                                  void* userCtx, uint32_t timeoutMs) {
-    if (isActive()) return false; // Fail-fast if pending request already active
-    if (closingInProgress()) return false; // Fail if either path is currently closing a previous request
+    if (isActive() || closingInProgress()) return false; // Fail-fast
 
     Lock guard(_mutex);
     
-    if (isActive()) return false; // Avoid corruption if another set() call won the lock race
+    if (isActive() || closingInProgress()) return false; // Avoid corruption & timer/response race
 
     _reqMetadata.type = Modbus::REQUEST;
     _reqMetadata.fc = request.fc;

--- a/src/apps/ModbusClient.h
+++ b/src/apps/ModbusClient.h
@@ -192,7 +192,7 @@ private:
     * Call sites never manage timers directly. They only:
     * - take a read-only snapshot for validation (to avoid long critical sections or torn reads),
     * - then call one of:
-    *   - setResponse(frame, finalize, fromTimer=false)
+    *   - setResponse(frame, finalize) -> only called from response path (not from timer)
     *   - setResult(result, finalize, fromTimer=false)
     *
     * These methods internally:

--- a/src/apps/ModbusClient.h
+++ b/src/apps/ModbusClient.h
@@ -197,7 +197,7 @@ private:
         bool snapshotIfActive(PendingSnapshot& out);
 
         // Timer neutralization method (used by Client)
-        bool killTimer();
+        bool killTimer(TickType_t maxWaitTicks = pdMS_TO_TICKS(TIMER_WAIT_MS));
 
         // Destructor
         ~PendingRequest();

--- a/src/apps/ModbusClient.h
+++ b/src/apps/ModbusClient.h
@@ -174,7 +174,7 @@ private:
     private:
         // Pending Request state variables
         Client* _client;                              // Pointer to parent Client for transport access in timeout callback
-        Modbus::Frame _reqMetadata;                   // Does not store request data (only fc, slaveId, regAddress, regCount)
+        Modbus::FrameMeta _reqMetadata;               // Lightweight metadata without data payload (~240 bytes saved)
         Modbus::Frame* _pResponse = nullptr;          // Pointer to response buffer (using sync or async w/ tracker)
         Result* _tracker = nullptr;                   // Pointer to user tracker (using async w/ tracker)
         ResponseCallback _cb = nullptr;               // Pointer to user callback (using async w/ callback)
@@ -203,7 +203,7 @@ private:
         bool isActive() const;
         bool hasResponse() const;
         uint32_t getTimestampMs() const;
-        const Modbus::Frame& getRequestMetadata() const;
+        const Modbus::FrameMeta& getRequestMetadata() const;
         // Locked methods
         void setResult(Result result, bool finalize, bool fromTimer = false);
         void setResponse(const Modbus::Frame& response, bool finalize, bool fromTimer = false);
@@ -211,7 +211,7 @@ private:
 
         // Snapshot helper for lock-free validation in handleResponse
         struct PendingSnapshot {
-            Modbus::Frame reqMetadata;
+            Modbus::FrameMeta reqMetadata;
         };
         bool snapshotIfActive(PendingSnapshot& out);
 

--- a/src/apps/ModbusClient.h
+++ b/src/apps/ModbusClient.h
@@ -285,7 +285,7 @@ private:
         std::atomic<uint32_t> _timerCbDisarmed;       // Flag to indicate whether the timer callback is disarmed
 
         // Atomic gates for closing race protection
-        std::atomic<uint32_t> _respClosing;            // Indicates whether the request is being closed via the "normal" path
+        std::atomic<uint32_t> _respClosing;           // Indicates whether the request is being closed via the "normal" path
         std::atomic<uint32_t> _timerClosing;          // Indicates whether the request is being closed via the "timeout callback" path
 
 

--- a/src/apps/ModbusClient.h
+++ b/src/apps/ModbusClient.h
@@ -144,7 +144,7 @@ private:
     * address all possile flaws, which makes up for a quite complex (but not complicated) solution
     * given the absence of native FreeRTOS primitives capable to solve this specific case (except
     * having a dedicated task to manage a Modbus::Client, which would be counter-productive in terms
-    * of memory resources & reactivity).)
+    * of memory resources & responsiveness).
     *
     * The design is deliberately epoch-free and single-timer (no rotating pools) to stay
     * as simple as possible despite the apparent complexity. It relies on four layers of defense 

--- a/src/apps/ModbusClient.h
+++ b/src/apps/ModbusClient.h
@@ -312,8 +312,9 @@ private:
         uint32_t getTimestampMs() const;
         const Modbus::FrameMeta& getRequestMetadata() const;
         // Locked methods
-        void setResult(Result result, bool finalize, bool fromTimer = false);
-        void setResponse(const Modbus::Frame& response, bool finalize, bool fromTimer = false);
+        void setResult(Result result, bool finalize = true, bool fromTimer = false);
+        void setResultFromTimer(Result result); // For use from timer context (same, with safe args)
+        void setResponse(const Modbus::Frame& response, bool finalize = true);
         void setSyncEventGroup(EventGroupHandle_t group);
 
         // Snapshot helper for lock-free validation in handleResponse

--- a/src/core/ModbusFrame.hpp
+++ b/src/core/ModbusFrame.hpp
@@ -91,6 +91,42 @@ private:
 };
 
 // ===================================================================================
+// FRAME METADATA STRUCTURE
+// ===================================================================================
+
+/* @brief Lightweight structure containing only frame metadata without data payload
+ * Used to store request/response information without the 250-byte data array
+ */
+struct FrameMeta {
+    MsgType type = NULL_MSG;
+    FunctionCode fc = NULL_FC;
+    uint8_t slaveId = 0;
+    uint16_t regAddress = 0;
+    uint16_t regCount = 0;
+    
+    // Default constructor
+    FrameMeta() = default;
+    
+    // Constructor from Frame
+    explicit FrameMeta(const Frame& frame) 
+        : type(frame.type), fc(frame.fc), slaveId(frame.slaveId), 
+          regAddress(frame.regAddress), regCount(frame.regCount) {}
+    
+    // Constructor with all fields
+    FrameMeta(MsgType msgType, FunctionCode funcCode, uint8_t slave, uint16_t addr, uint16_t count)
+        : type(msgType), fc(funcCode), slaveId(slave), regAddress(addr), regCount(count) {}
+    
+    // Clear function (same as Frame::clear but without data)
+    void clear() {
+        type = NULL_MSG;
+        fc = NULL_FC;
+        slaveId = 0;
+        regAddress = 0;
+        regCount = 0;
+    }
+};
+
+// ===================================================================================
 // INLINE FUNCTIONS - IN-PLACE DATA PACKING/UNPACKING IN MODBUS::FRAME
 // ===================================================================================
 

--- a/src/core/ModbusTypes.hpp
+++ b/src/core/ModbusTypes.hpp
@@ -13,6 +13,7 @@
 #include <vector>
 #include <functional>
 #include <algorithm>
+#include <atomic>
 
 // Do not include timing macros & FreeRTOS types if NATIVE_TEST is defined
 #ifndef NATIVE_TEST

--- a/src/core/ModbusTypes.hpp
+++ b/src/core/ModbusTypes.hpp
@@ -99,6 +99,33 @@ private:
     volatile bool _locked;
 };
 
+/* @brief RAII wrapper for a FreeRTOS binary semaphore
+*/
+class BinarySemaphore {
+public:
+    BinarySemaphore() { 
+        _sem = xSemaphoreCreateBinaryStatic(&_semBuf); 
+        configASSERT(_sem);
+        // Give the semaphore initially so first take() succeeds
+        xSemaphoreGive(_sem);
+    }
+    ~BinarySemaphore() {} // Static Semaphore : no call to vSemaphoreDelete needed
+    BinarySemaphore(const BinarySemaphore&) = delete;
+    BinarySemaphore& operator=(const BinarySemaphore&) = delete;
+    
+    inline bool take(TickType_t wait = portMAX_DELAY) { return xSemaphoreTake(_sem, wait) == pdTRUE; }
+    inline bool tryTake() { return xSemaphoreTake(_sem, 0) == pdTRUE; }
+    inline void give() const { BaseType_t ok = xSemaphoreGive(_sem); configASSERT(ok == pdTRUE); }
+    inline void giveForce() const { (void)xSemaphoreGive(_sem); }
+    __attribute__((always_inline)) inline void giveFromISR(BaseType_t* pxHigherPriorityTaskWoken) { 
+        xSemaphoreGiveFromISR(_sem, pxHigherPriorityTaskWoken); 
+    }
+
+private:
+    StaticSemaphore_t _semBuf;
+    SemaphoreHandle_t _sem;
+};
+
 #endif // NATIVE_TEST
 
 


### PR DESCRIPTION
This PR solves the hypothetical race conditions identified in issue #12.

The main challenge was to ensure proper concurrency between the FreeRTOS timer that closes timeouted requests, and the "normal path" (response received) which can both hit at the very same time, creating risks on the outcome of the request being closed and the following one if the user-side client code is very fast (not corruption, but inconsistency). In order to solve this, various safety measures have been implemented in `Modbus::Client::PendingRequest`, explained in a long comment in the `ModbusClient.h` file. 

The current implementation seems quite exhaustive as it solves all possible corner cases that could be identified at this point. It might seem a bit complex, but is almost zero-cost in terms of RAM and runtime latency, and totally avoids having to resort to a dedicated task to manage request timeout: `Modbus::Client` can remain a simple class without any execution context, saving lots of RAM & scheduler overhead.

Also, I identified another hypothetical issue when sending a request, as the creation of the sync waiter EventGroup was delegated to the `PendingRequest` class: now, the creation is done directly in `Client::sendRequest` and we just pass its handle to `PendingRequest::set()`.