### PR TITLE
260301 2333 runtime editable serial config

### DIFF
--- a/docs/20-core-concepts/205-hal-wrappers.md
+++ b/docs/20-core-concepts/205-hal-wrappers.md
@@ -133,6 +133,12 @@ uart.setConfig(ModbusHAL::UART::makeConfig(UART_DATA_8_BITS, UART_PARITY_ODD, UA
 
 If the driver is already running, changes are applied immediately via `uart_param_config()` without requiring a restart. If called before `begin()`, the values are stored and applied at startup.
 
+!!! warning
+    Reconfiguring the UART while a frame is in transit will corrupt it - `uart_param_config()` resets the hardware FIFOs internally. In practice this is harmless: the corrupted frame will fail its CRC check and be silently discarded, just like any other bus glitch. However, if both sides of the bus need to change config (e.g. switching from 9600 8N1 to 19200 8E1), make sure to reconfigure **all** peers before sending the next request, otherwise the mismatch will cause repeated CRC failures.
+
+!!! tip
+    On a slave device, do not apply the new serial settings directly inside the Modbus write handler. If you do, the response to the write command will already be sent with the new config while the client is still listening with the old one, so it will never receive the acknowledgement. Instead, set a flag in the handler and apply the change asynchronously after a short delay (e.g. in your main loop), giving the response time to be fully transmitted first.
+
 Getters are also available:
 
 ```cpp

--- a/docs/20-core-concepts/205-hal-wrappers.md
+++ b/docs/20-core-concepts/205-hal-wrappers.md
@@ -113,6 +113,34 @@ The HAL RTU object is then passed to the Modbus interface:
 ModbusInterface::RTU rtu(uart, Modbus::CLIENT);
 ```
 
+#### Runtime reconfiguration
+
+The UART driver supports live reconfiguration of serial parameters (baud rate, data bits, parity, stop bits) at any time - both before and after `begin()`. Start with a sensible default (e.g. `9600 8N1`) and call the setters when you need to change:
+
+```cpp
+// Change everything at once using a CONFIG_xxx constant
+uart.setConfig(ModbusHAL::UART::CONFIG_8E1);
+
+// Or change individual parameters
+uart.setBaudrate(19200);
+uart.setParity(UART_PARITY_EVEN);
+uart.setStopBits(UART_STOP_BITS_2);
+uart.setDataBits(UART_DATA_7_BITS);
+
+// Or build a custom config from individual values
+uart.setConfig(ModbusHAL::UART::makeConfig(UART_DATA_8_BITS, UART_PARITY_ODD, UART_STOP_BITS_1));
+```
+
+If the driver is already running, changes are applied immediately via `uart_param_config()` without requiring a restart. If called before `begin()`, the values are stored and applied at startup.
+
+Getters are also available:
+
+```cpp
+uint32_t baud   = uart.getBaudrate();  // Current baud rate
+uint32_t config = uart.getConfig();    // Current packed config flags
+```
+
+Since `getConfig()` and `getBaudrate()` return plain integers, they can be saved to non-volatile storage (NVS, EEPROM, Flash) and restored on boot - useful for devices that allow serial settings to be changed at runtime (e.g. over Modbus).
 
 
 ## ModbusHAL::TCP - TCP socket driver

--- a/docs/30-how-to-guides/301-modbus-server-slave.md
+++ b/docs/30-how-to-guides/301-modbus-server-slave.md
@@ -84,6 +84,19 @@ The default behaviour ensures 100% request hit rate but may be prone to deadlock
 
 **Interface limits**: The server enforces a maximum number of interfaces defined at compile time (2 by default). This limit can be adjusted using the `EZMODBUS_SERVER_MAX_INTERFACES` build flag if more interfaces are needed.
 
+### Changing the Slave ID at runtime
+
+The server's Slave ID can be changed at runtime using `setSlaveId()`. This is thread-safe: the method acquires the server mutex, so it will block until any in-flight request completes before updating the ID.
+
+```cpp
+server.setSlaveId(newId);
+```
+
+This is useful for devices that allow their Modbus address to be reconfigured over the bus (e.g. via a dedicated holding register). The getter `getSlaveId()` is also available.
+
+!!! note
+    If the address change is triggered by a Modbus write handler, avoid calling `setSlaveId()` directly inside the handler - the server mutex is already held during request processing, so this would deadlock. Instead, defer the change (e.g. set a flag and apply it in your main loop after the response has been sent).
+
 ### Words storage & memory management
 
 Words are stored on the server inside a `Modbus::WordStore` container which can store an arbitrary number of `Word` objects regardless of their underlying `RegisterType`. This container is created in user code space (to keep in control of memory allocation) but directly managed by the Server.

--- a/src/apps/ModbusServer.cpp
+++ b/src/apps/ModbusServer.cpp
@@ -140,6 +140,17 @@ Server::Result Server::clearAllWords() {
     return Success();
 }
 
+/* @brief Change the server's Slave/Unit ID at runtime
+ * @param id New Slave/Unit ID
+ * @note Thread-safe: acquires the server mutex to prevent concurrent access
+ *       with request processing. Blocks until any in-flight request completes.
+ *       -> Do NOT call inside a handler or it will deadlock!
+ */
+void Server::setSlaveId(uint8_t id) {
+    Lock guard(_serverMutex);
+    _serverId = id;
+}
+
 /* @brief Check if the server is busy
  * @return true if the server is busy (adding a word or processing a request)
  */

--- a/src/apps/ModbusServer.h
+++ b/src/apps/ModbusServer.h
@@ -154,6 +154,9 @@ public:
     
     bool isBusy();
 
+    uint8_t getSlaveId() const { return _serverId; }
+    void setSlaveId(uint8_t id);
+
 private:
     // ===================================================================================
     // PRIVATE TYPES

--- a/src/drivers/ModbusHAL_UART.cpp
+++ b/src/drivers/ModbusHAL_UART.cpp
@@ -236,6 +236,53 @@ esp_err_t UART::setBaudrate(uint32_t baud_rate) {
     return err;
 }
 
+/* @brief Set the serial config (data bits, parity, stop bits) of the UART driver
+ * @param config_flags: Packed config flags (use CONFIG_xxx constants, e.g. CONFIG_8N1)
+ * @return ESP_OK on success
+ * @note If the driver is already running, the new config is applied immediately
+ *       via uart_param_config() without requiring a restart.
+ */
+esp_err_t UART::setConfig(uint32_t config_flags) {
+    _config_flags = config_flags;
+    decode_config_flags(_config_flags, _current_hw_config.data_bits, _current_hw_config.parity, _current_hw_config.stop_bits);
+
+    if (!_is_driver_installed) {
+        Modbus::Debug::LOG_MSGF("Info: Port %d config set to 0x%X (will be applied at begin())", _uart_num, (unsigned int)_config_flags);
+        return ESP_OK;
+    }
+    esp_err_t err = uart_param_config(_uart_num, &_current_hw_config);
+    if (err == ESP_OK) {
+        Modbus::Debug::LOG_MSGF("Info: Port %d config reconfigured to 0x%X", _uart_num, (unsigned int)_config_flags);
+    } else {
+        Modbus::Debug::LOG_MSGF("Error: Port %d failed to reconfigure config to 0x%X: %s", _uart_num, (unsigned int)config_flags, esp_err_to_name(err));
+    }
+    return err;
+}
+
+/* @brief Set only the parity of the UART driver
+ * @param parity: The parity to set (UART_PARITY_DISABLE, UART_PARITY_EVEN, UART_PARITY_ODD)
+ * @return ESP_OK on success
+ */
+esp_err_t UART::setParity(uart_parity_t parity) {
+    return setConfig(makeConfig(_current_hw_config.data_bits, parity, _current_hw_config.stop_bits));
+}
+
+/* @brief Set only the stop bits of the UART driver
+ * @param stop_bits: The stop bits to set (UART_STOP_BITS_1, UART_STOP_BITS_2)
+ * @return ESP_OK on success
+ */
+esp_err_t UART::setStopBits(uart_stop_bits_t stop_bits) {
+    return setConfig(makeConfig(_current_hw_config.data_bits, _current_hw_config.parity, stop_bits));
+}
+
+/* @brief Set only the data bits of the UART driver
+ * @param data_bits: The data bits to set (UART_DATA_5_BITS .. UART_DATA_8_BITS)
+ * @return ESP_OK on success
+ */
+esp_err_t UART::setDataBits(uart_word_length_t data_bits) {
+    return setConfig(makeConfig(data_bits, _current_hw_config.parity, _current_hw_config.stop_bits));
+}
+
 /* @brief Wait for the physical transmission to complete
  * @param timeout_ticks: The number of ticks to wait for the transmission to complete
  * @return ESP_OK on success, ESP_ERR_INVALID_STATE if the driver is not installed

--- a/src/drivers/ModbusHAL_UART.h
+++ b/src/drivers/ModbusHAL_UART.h
@@ -138,7 +138,17 @@ public:
 
     // UART config methods
     uint32_t getBaudrate() const { return _baud_rate; }
-    esp_err_t setBaudrate(uint32_t baud_rate); 
+    esp_err_t setBaudrate(uint32_t baud_rate);
+    uint32_t getConfig() const { return _config_flags; }
+    esp_err_t setConfig(uint32_t config_flags);
+    esp_err_t setParity(uart_parity_t parity);
+    esp_err_t setStopBits(uart_stop_bits_t stop_bits);
+    esp_err_t setDataBits(uart_word_length_t data_bits);
+
+    // Helper to build config flags from individual parameters
+    static constexpr uint32_t makeConfig(uart_word_length_t data, uart_parity_t parity, uart_stop_bits_t stop) {
+        return static_cast<uint32_t>(data) | (static_cast<uint32_t>(parity) << 8) | (static_cast<uint32_t>(stop) << 16);
+    }
     uart_port_t getPort() const { return _uart_num; }
     QueueHandle_t getRegisteredEventQueue() const { return _internal_event_queue_handle; } // Renommé pour clarté
 

--- a/test/test_rtu_client_loopback/test_main.cpp
+++ b/test/test_rtu_client_loopback/test_main.cpp
@@ -1621,12 +1621,104 @@ void test_callback_timeout() {
     vTaskDelay(pdMS_TO_TICKS(100));
 }
 
+// ===================================================================================
+// RUNTIME UART RECONFIGURATION TESTS
+// ===================================================================================
+
+void test_runtime_uart_reconfig() {
+    Modbus::Logger::logln();
+    Modbus::Logger::logln("TEST_RUNTIME_UART_RECONFIG: CHANGE BAUDRATE + SERIAL CONFIG AT RUNTIME");
+
+    // Save original config
+    const uint32_t origBaud = ezm_uart.getBaudrate();
+    const uint32_t origConfig = ezm_uart.getConfig();
+
+    // 1) Sanity check: read at current config -> should work
+    {
+        Modbus::Frame req = {
+            .type = Modbus::REQUEST,
+            .fc = Modbus::READ_HOLDING_REGISTERS,
+            .slaveId = TEST_SLAVE_ID,
+            .regAddress = READ_HOLDING_ADDR,
+            .regCount = 1,
+            .data = {},
+            .exceptionCode = Modbus::NULL_EXCEPTION
+        };
+        Modbus::Frame resp;
+        auto res = client.sendRequest(req, resp, nullptr);  // nullptr = synchronous
+        TEST_ASSERT_EQUAL_MESSAGE(Modbus::Client::SUCCESS, res, "Baseline read before reconfig should succeed");
+        TEST_ASSERT_EQUAL_MESSAGE(MBT_INIT_HOLDING_REGISTER_VALUE(READ_HOLDING_ADDR), resp.getRegister(0),
+            "Baseline read value mismatch");
+    }
+
+    // 2) Reconfigure BOTH sides to 19200 8E1
+    const uint32_t newBaud = 19200;
+    const uint32_t newConfig = ModbusHAL::UART::CONFIG_8E1;
+
+    ezm_uart.setBaudrate(newBaud);
+    ezm_uart.setConfig(newConfig);
+    mbt_uart.setBaudrate(newBaud);
+    mbt_uart.setConfig(newConfig);
+    vTaskDelay(pdMS_TO_TICKS(50)); // Let hardware settle
+
+    // Flush stale data from both sides
+    ezm_uart.flush_input();
+    mbt_uart.flush_input();
+    vTaskDelay(pdMS_TO_TICKS(20));
+
+    // 3) Read again -> should succeed at new config
+    {
+        Modbus::Frame req = {
+            .type = Modbus::REQUEST,
+            .fc = Modbus::READ_HOLDING_REGISTERS,
+            .slaveId = TEST_SLAVE_ID,
+            .regAddress = READ_HOLDING_ADDR,
+            .regCount = 1,
+            .data = {},
+            .exceptionCode = Modbus::NULL_EXCEPTION
+        };
+        Modbus::Frame resp;
+        auto res = client.sendRequest(req, resp, nullptr);
+        TEST_ASSERT_EQUAL_MESSAGE(Modbus::Client::SUCCESS, res, "Read after reconfig to 19200 8E1 should succeed");
+        TEST_ASSERT_EQUAL_MESSAGE(MBT_INIT_HOLDING_REGISTER_VALUE(READ_HOLDING_ADDR), resp.getRegister(0),
+            "Read value after reconfig mismatch");
+    }
+
+    // 4) Restore original config
+    ezm_uart.setBaudrate(origBaud);
+    ezm_uart.setConfig(origConfig);
+    mbt_uart.setBaudrate(origBaud);
+    mbt_uart.setConfig(origConfig);
+    vTaskDelay(pdMS_TO_TICKS(50));
+    ezm_uart.flush_input();
+    mbt_uart.flush_input();
+    vTaskDelay(pdMS_TO_TICKS(20));
+
+    // 5) Verify restored config works
+    {
+        Modbus::Frame req = {
+            .type = Modbus::REQUEST,
+            .fc = Modbus::READ_HOLDING_REGISTERS,
+            .slaveId = TEST_SLAVE_ID,
+            .regAddress = READ_HOLDING_ADDR,
+            .regCount = 1,
+            .data = {},
+            .exceptionCode = Modbus::NULL_EXCEPTION
+        };
+        Modbus::Frame resp;
+        auto res = client.sendRequest(req, resp, nullptr);
+        TEST_ASSERT_EQUAL_MESSAGE(Modbus::Client::SUCCESS, res, "Read after restoring original config should succeed");
+        TEST_ASSERT_EQUAL_MESSAGE(MBT_INIT_HOLDING_REGISTER_VALUE(READ_HOLDING_ADDR), resp.getRegister(0),
+            "Read value after restore mismatch");
+    }
+}
+
 void setup() {
     // Debug port
     Serial.setTxBufferSize(2048);
     Serial.setRxBufferSize(2048);
     Serial.begin(115200);
-    
+
     // Initialize UART HAL for client
     Modbus::Logger::logln("[setup] Initializing client UART HAL...");
     esp_err_t uart_init_res = ezm_uart.begin();
@@ -1719,6 +1811,9 @@ void setup() {
     RUN_TEST(test_helper_null_buffer);
     RUN_TEST(test_helper_qty_zero);
     RUN_TEST(test_helper_write_readonly_regtype);
+
+    // Runtime reconfiguration tests
+    RUN_TEST(test_runtime_uart_reconfig);
 
     UNITY_END();
 }

--- a/test/test_rtu_server_loopback/test_main.cpp
+++ b/test/test_rtu_server_loopback/test_main.cpp
@@ -1857,6 +1857,46 @@ void test_gap_handling_comprehensive() {
 }
 
 
+// ===================================================================================
+// RUNTIME RECONFIGURATION TESTS
+// ===================================================================================
+
+void test_runtime_set_slave_id() {
+    Modbus::Logger::logln("\nTEST_RUNTIME_SET_SLAVE_ID");
+
+    // Verify initial Slave ID
+    TEST_ASSERT_EQUAL(1, server.getSlaveId());
+
+    // Add a holding register with a known value
+    DummyWord1Reg hr(Modbus::HOLDING_REGISTER, 500);
+    hr.value = 0xBEEF;
+    do_test_add_word(server, hr.word, true, "Add HR@500 for slaveId test");
+
+    // 1) Read at original Slave ID 1 -> should succeed
+    int val = testClient.holdingRegisterRead(1, 500);
+    TEST_ASSERT_START();
+    TEST_ASSERT_EQUAL_MESSAGE(0xBEEF, val, "Read at original SlaveID=1 should succeed");
+
+    // 2) Change Slave ID to 42
+    server.setSlaveId(42);
+    TEST_ASSERT_EQUAL(42, server.getSlaveId());
+    vTaskDelay(pdMS_TO_TICKS(50)); // Let the bus settle
+
+    // 3) Read at old Slave ID 1 -> should timeout (no response)
+    val = testClient.holdingRegisterRead(1, 500);
+    TEST_ASSERT_START();
+    TEST_ASSERT_EQUAL_MESSAGE(-1, val, "Read at old SlaveID=1 should fail (no response)");
+
+    // 4) Read at new Slave ID 42 -> should succeed
+    val = testClient.holdingRegisterRead(42, 500);
+    TEST_ASSERT_START();
+    TEST_ASSERT_EQUAL_MESSAGE(0xBEEF, val, "Read at new SlaveID=42 should succeed");
+
+    // 5) Restore original Slave ID for subsequent tests
+    server.setSlaveId(1);
+    TEST_ASSERT_EQUAL(1, server.getSlaveId());
+}
+
 void setup() {
     // Debug port
     Serial.setTxBufferSize(2048);
@@ -1952,7 +1992,10 @@ void setup() {
     
     // Gap handling tests (rejectUndefined = false)
     RUN_TEST(test_gap_handling_comprehensive);
-    
+
+    // Runtime reconfiguration tests
+    RUN_TEST(test_runtime_set_slave_id);
+
     // Migration test - COMMENTED OUT (Register API removed)
     // RUN_TEST(test_register_to_word_migration);
 


### PR DESCRIPTION
This PR adds the possibility to:

1. Edit RS485 UART settings for Modbus RTU (baudrate, parity, data bits, stop bits) at runtime
2. Change `Modbus::Server` Slave ID at runtime

This is especially useful for slave devices that can be hot-reconfigured through the Modbus interface itself (or another API). A warning/tip are added in the docs about the consequences of calling those methods in Modbus handlers.

Specific test cases were added to the RTU client & server tests. 